### PR TITLE
Add sortable columns to CSV viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,8 +270,15 @@
       });
     }
 
+    let lastSortColumn = null;
+    let lastSortAscending = null;
+
     function sortResults() {
       if (!sortColumn) return;
+      // Skip sorting if the sort criteria haven't changed
+      if (sortColumn === lastSortColumn && sortAscending === lastSortAscending) {
+        return;
+      }
       currentResults.sort((a, b) => {
         const valA = String(a[sortColumn] || '').toLowerCase();
         const valB = String(b[sortColumn] || '').toLowerCase();

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
 
     // Build clickable sort buttons for each column
     function buildSortButtons() {
-      sortContainer.innerHTML = "";
+      sortContainer.replaceChildren();
       columns.forEach(field => {
         const btn = document.createElement('button');
         btn.dataset.column = field;

--- a/index.html
+++ b/index.html
@@ -280,11 +280,23 @@
         return;
       }
       currentResults.sort((a, b) => {
-        const valA = String(a[sortColumn] || '').toLowerCase();
-        const valB = String(b[sortColumn] || '').toLowerCase();
-        if (valA < valB) return sortAscending ? -1 : 1;
-        if (valA > valB) return sortAscending ? 1 : -1;
-        return 0;
+        const valA = a[sortColumn];
+        const valB = b[sortColumn];
+        
+        const isNumericA = !isNaN(Number(valA));
+        const isNumericB = !isNaN(Number(valB));
+        
+        if (isNumericA && isNumericB) {
+          // Numeric comparison
+          return sortAscending ? valA - valB : valB - valA;
+        } else {
+          // String comparison (case-insensitive)
+          const strA = String(valA || '').toLowerCase();
+          const strB = String(valB || '').toLowerCase();
+          if (strA < strB) return sortAscending ? -1 : 1;
+          if (strA > strB) return sortAscending ? 1 : -1;
+          return 0;
+        }
       });
     }
 

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
     <!-- Results Area -->
     <div id="resultsArea" class="mb-10 hidden">
       <h2 class="text-2xl font-bold mb-4 text-blue-800">Search Results</h2>
+      <div id="sortContainer" class="mb-4 flex flex-wrap gap-2"></div>
       <div id="resultsContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
       <!-- Pagination Controls -->
       <div id="pagination" class="mt-4 flex justify-between items-center">
@@ -98,6 +99,8 @@
     let currentResults = [];
     let currentPage = 1;
     const resultsPerPage = 25;
+    let sortColumn = null;
+    let sortAscending = true;
     // DOM Elements
     const dragArea = document.getElementById('dragArea');
     const fileInput = document.getElementById('fileInput');
@@ -111,6 +114,7 @@
     const pageInfo = document.getElementById('pageInfo');
     const filterContainer = document.getElementById('filterContainer');
     const filtersDiv = document.getElementById('filters');
+    const sortContainer = document.getElementById('sortContainer');
 
     // Prevent default drag behaviors
     ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
@@ -174,6 +178,7 @@
           resultsArea.classList.remove('hidden');
           // Build dynamic filter dropdowns for each column that has at least one non-empty value
           buildFilters();
+          buildSortButtons();
           // Set initial results to all records and display first page
           currentResults = csvData;
           currentPage = 1;
@@ -230,6 +235,52 @@
       filterContainer.classList.remove('hidden');
     }
 
+    // Build clickable sort buttons for each column
+    function buildSortButtons() {
+      sortContainer.innerHTML = "";
+      columns.forEach(field => {
+        const btn = document.createElement('button');
+        btn.dataset.column = field;
+        btn.className = "px-2 py-1 border border-blue-300 rounded text-sm bg-white";
+        btn.addEventListener('click', () => {
+          if (sortColumn === field) {
+            sortAscending = !sortAscending;
+          } else {
+            sortColumn = field;
+            sortAscending = true;
+          }
+          updateSortUI();
+          displayResults();
+        });
+        sortContainer.appendChild(btn);
+      });
+      updateSortUI();
+    }
+
+    function updateSortUI() {
+      Array.from(sortContainer.children).forEach(btn => {
+        const col = btn.dataset.column;
+        if (col === sortColumn) {
+          btn.classList.add('bg-blue-100');
+          btn.innerHTML = `${col} ${sortAscending ? '▲' : '▼'}`;
+        } else {
+          btn.classList.remove('bg-blue-100');
+          btn.textContent = col;
+        }
+      });
+    }
+
+    function sortResults() {
+      if (!sortColumn) return;
+      currentResults.sort((a, b) => {
+        const valA = String(a[sortColumn] || '').toLowerCase();
+        const valB = String(b[sortColumn] || '').toLowerCase();
+        if (valA < valB) return sortAscending ? -1 : 1;
+        if (valA > valB) return sortAscending ? 1 : -1;
+        return 0;
+      });
+    }
+
     // Update results based on search input and filter selections
     function updateResults() {
       const term = searchInput.value.trim();
@@ -253,6 +304,7 @@
     // Display results as cards for the current page
     function displayResults() {
       resultsContainer.innerHTML = "";
+      sortResults();
       const startIdx = (currentPage - 1) * resultsPerPage;
       const endIdx = startIdx + resultsPerPage;
       const pageResults = currentResults.slice(startIdx, endIdx);


### PR DESCRIPTION
## Summary
- allow sorting by column with header buttons
- remember current sort order while paging and searching

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a3d00cd488332ae81c4ad1ff0e544