### PR TITLE
Add table view toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
       resultsContainer.appendChild(table);
 
       const totalPages = calculateTotalPages(currentResults, resultsPerPage);
-      resultCount.textContent = `Showing ${currentResults.length} result${currentResults.length === 1 ? '' : 's'}.`;
+      resultCount.textContent = generateResultCountText(currentResults.length);
       pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
 
       prevBtn.disabled = currentPage <= 1;

--- a/index.html
+++ b/index.html
@@ -76,6 +76,11 @@
     <!-- Results Area -->
     <div id="resultsArea" class="mb-10 hidden">
       <h2 class="text-2xl font-bold mb-4 text-blue-800">Search Results</h2>
+      <div class="flex justify-end mb-2">
+        <button id="toggleViewBtn" class="px-4 py-2 bg-blue-500 text-white rounded">
+          Table View
+        </button>
+      </div>
       <div id="resultsContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
       <!-- Pagination Controls -->
       <div id="pagination" class="mt-4 flex justify-between items-center">
@@ -98,6 +103,9 @@
     let currentResults = [];
     let currentPage = 1;
     const resultsPerPage = 25;
+    let viewMode = 'card';
+    const cardContainerClass = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6';
+    const tableContainerClass = 'overflow-x-auto';
     // DOM Elements
     const dragArea = document.getElementById('dragArea');
     const fileInput = document.getElementById('fileInput');
@@ -105,12 +113,21 @@
     const fileStatus = document.getElementById('fileStatus');
     const resultsArea = document.getElementById('resultsArea');
     const resultsContainer = document.getElementById('resultsContainer');
+    const toggleViewBtn = document.getElementById('toggleViewBtn');
     const resultCount = document.getElementById('resultCount');
     const prevBtn = document.getElementById('prevBtn');
     const nextBtn = document.getElementById('nextBtn');
     const pageInfo = document.getElementById('pageInfo');
     const filterContainer = document.getElementById('filterContainer');
     const filtersDiv = document.getElementById('filters');
+
+    // Toggle between card and table views
+    toggleViewBtn.addEventListener('click', () => {
+      viewMode = viewMode === 'card' ? 'table' : 'card';
+      toggleViewBtn.textContent = viewMode === 'card' ? 'Table View' : 'Card View';
+      resultsContainer.className = viewMode === 'card' ? cardContainerClass : tableContainerClass;
+      renderResults();
+    });
 
     // Prevent default drag behaviors
     ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
@@ -177,7 +194,7 @@
           // Set initial results to all records and display first page
           currentResults = csvData;
           currentPage = 1;
-          displayResults();
+          renderResults();
         } catch (error) {
           console.error("CSV parse error:", error);
           fileStatus.textContent = 'Error parsing CSV: ' + error.message;
@@ -247,7 +264,7 @@
       
       currentResults = filtered;
       currentPage = 1;
-      displayResults();
+      renderResults();
     }
 
     // Display results as cards for the current page
@@ -282,18 +299,70 @@
       nextBtn.disabled = currentPage >= totalPages;
     }
 
+    // Display results as a table for the current page
+    function displayTableResults() {
+      resultsContainer.innerHTML = "";
+      const startIdx = (currentPage - 1) * resultsPerPage;
+      const endIdx = startIdx + resultsPerPage;
+      const pageResults = currentResults.slice(startIdx, endIdx);
+
+      const table = document.createElement('table');
+      table.className = 'min-w-full divide-y divide-blue-200 border';
+      const thead = document.createElement('thead');
+      thead.className = 'bg-blue-50';
+      const headerRow = document.createElement('tr');
+      columns.forEach(col => {
+        const th = document.createElement('th');
+        th.textContent = col;
+        th.className = 'px-4 py-2 text-left text-blue-700';
+        headerRow.appendChild(th);
+      });
+      thead.appendChild(headerRow);
+      table.appendChild(thead);
+
+      const tbody = document.createElement('tbody');
+      pageResults.forEach(record => {
+        const row = document.createElement('tr');
+        columns.forEach(col => {
+          const td = document.createElement('td');
+          td.textContent = record[col] || '';
+          td.className = 'px-4 py-2 border-t';
+          row.appendChild(td);
+        });
+        tbody.appendChild(row);
+      });
+      table.appendChild(tbody);
+      resultsContainer.appendChild(table);
+
+      const totalPages = Math.ceil(currentResults.length / resultsPerPage);
+      resultCount.textContent = `Showing ${currentResults.length} result${currentResults.length === 1 ? '' : 's'}.`;
+      pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
+
+      prevBtn.disabled = currentPage <= 1;
+      nextBtn.disabled = currentPage >= totalPages;
+    }
+
+    // Render results based on current view mode
+    function renderResults() {
+      if (viewMode === 'table') {
+        displayTableResults();
+      } else {
+        displayResults();
+      }
+    }
+
     // Pagination controls
     prevBtn.addEventListener('click', () => {
       if (currentPage > 1) {
         currentPage--;
-        displayResults();
+        renderResults();
       }
     });
     nextBtn.addEventListener('click', () => {
       const totalPages = Math.ceil(currentResults.length / resultsPerPage);
       if (currentPage < totalPages) {
         currentPage++;
-        displayResults();
+        renderResults();
       }
     });
     

--- a/index.html
+++ b/index.html
@@ -334,7 +334,7 @@
       table.appendChild(tbody);
       resultsContainer.appendChild(table);
 
-      const totalPages = Math.ceil(currentResults.length / resultsPerPage);
+      const totalPages = calculateTotalPages(currentResults, resultsPerPage);
       resultCount.textContent = `Showing ${currentResults.length} result${currentResults.length === 1 ? '' : 's'}.`;
       pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
 

--- a/index.html
+++ b/index.html
@@ -334,7 +334,7 @@
       table.appendChild(tbody);
       resultsContainer.appendChild(table);
 
-      const totalPages = calculateTotalPages(currentResults, resultsPerPage);
+      const totalPages = Math.ceil(currentResults.length / resultsPerPage);
       resultCount.textContent = generateResultCountText(currentResults.length);
       pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
 


### PR DESCRIPTION
## Summary
- add a view toggle button
- implement new `displayTableResults()` function for rendering results in a table
- support switching between card and table layouts while preserving pagination

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_684a551d9f788332936ba04f51559079