### PR TITLE
chore: trigger security lock regeneration

### DIFF
--- a/.github/lock-regeneration-trigger-2
+++ b/.github/lock-regeneration-trigger-2
@@ -1,0 +1,1 @@
+trigger via PR merge


### PR DESCRIPTION
Temporary trigger PR into the remediation branch so GitHub emits a server-side push event and runs the scoped lockfile-regeneration workflow. This trigger file will be removed before the remediation PR is merged to main.